### PR TITLE
Fix some code liting and deprecated assert functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 build
 .eggs
 *.bat
+.vscode/

--- a/analytics/test/client.py
+++ b/analytics/test/client.py
@@ -322,7 +322,7 @@ class TestClient(unittest.TestCase):
                         flush_at=10, flush_interval=3)
 
         def mock_post_fn(*args, **kwargs):
-            self.assertEquals(len(kwargs['batch']), 10)
+            self.assertEqual(len(kwargs['batch']), 10)
 
         # the post function should be called 2 times, with a batch size of 10
         # each time.
@@ -331,14 +331,14 @@ class TestClient(unittest.TestCase):
             for _ in range(20):
                 client.identify('userId', {'trait': 'value'})
             time.sleep(1)
-            self.assertEquals(mock_post.call_count, 2)
+            self.assertEqual(mock_post.call_count, 2)
 
     def test_user_defined_timeout(self):
         client = Client('testsecret', timeout=10)
         for consumer in client.consumers:
-            self.assertEquals(consumer.timeout, 10)
+            self.assertEqual(consumer.timeout, 10)
 
     def test_default_timeout_15(self):
         client = Client('testsecret')
         for consumer in client.consumers:
-            self.assertEquals(consumer.timeout, 15)
+            self.assertEqual(consumer.timeout, 15)

--- a/analytics/test/consumer.py
+++ b/analytics/test/consumer.py
@@ -195,4 +195,4 @@ class TestConsumer(unittest.TestCase):
             for _ in range(0, n_msgs + 2):
                 q.put(track)
             q.join()
-            self.assertEquals(mock_post.call_count, 2)
+            self.assertEqual(mock_post.call_count, 2)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-
+from version import VERSION
 import os
 import sys
 
@@ -9,7 +9,6 @@ except ImportError:
 
 # Don't import analytics-python module here, since deps may not be installed
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'analytics'))
-from version import VERSION
 
 long_description = '''
 Segment is the simplest way to integrate analytics into your application.


### PR DESCRIPTION
- Some tests were using deprecated `assertEquals` function. That could be a problem in the future.
- Fixing minimal linting problems in the code.